### PR TITLE
Server conversation timestamps

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -161,6 +161,11 @@ module.exports = function(port, db, githubAuthoriser) {
                     contents: message,
                     timestamp: timestamp
                 }).then(function(result) {
+                    conversations.updateOne({
+                        _id: conversationID
+                    }, {
+                        $set: {lastTimestamp: timestamp}
+                    });
                     res.json(cleanIdField(result.ops[0]));
                 }).catch(function(err) {
                     res.sendStatus(500);

--- a/server/server.js
+++ b/server/server.js
@@ -182,6 +182,7 @@ module.exports = function(port, db, githubAuthoriser) {
         var senderID = req.session.user;
         var conversationID = req.params.id;
         var lastTimestamp = req.query.timestamp;
+        var countOnly = req.query.countOnly;
         conversations.find({
             _id: conversationID
         }).limit(1).next().then(function(conversation) {
@@ -193,11 +194,19 @@ module.exports = function(port, db, githubAuthoriser) {
                 if (lastTimestamp) {
                     queryObject.timestamp = {$gt: new Date(lastTimestamp)};
                 }
-                messages.find(queryObject).toArray().then(function(docs) {
-                    res.json(docs.map(cleanIdField));
-                }).catch(function(err) {
-                    res.sendStatus(500);
-                });
+                if (countOnly) {
+                    messages.count(queryObject).then(function(count) {
+                        res.json({count: count});
+                    }).catch(function(err) {
+                        res.sendStatus(500);
+                    });
+                } else {
+                    messages.find(queryObject).toArray().then(function(docs) {
+                        res.json(docs.map(cleanIdField));
+                    }).catch(function(err) {
+                        res.sendStatus(500);
+                    });
+                }
             } else {
                 res.sendStatus(403);
             }

--- a/test/server.js
+++ b/test/server.js
@@ -435,12 +435,8 @@ describe("server", function() {
                     var insertedMessage = helpers.getInsertOneArgs("messages", 0)[0];
                     assert.equal(insertedMessage.conversationID, testConversation._id);
                     assert.equal(insertedMessage.contents, testMessage.contents);
-                    assert(beforeTimestamp.getTime() <= insertedMessage.timestamp.getTime(),
-                        "Timestamp is earlier than call"
-                    );
-                    assert(insertedMessage.timestamp.getTime() <= afterTimestamp.getTime(),
-                        "Timestamp is later than call"
-                    );
+                    assert.isAtLeast(insertedMessage.timestamp.getTime(), beforeTimestamp.getTime());
+                    assert.isAtMost(insertedMessage.timestamp.getTime(), afterTimestamp.getTime());
                 });
             }
         );
@@ -485,13 +481,8 @@ describe("server", function() {
                     });
                     assert.isDefined(updateObject.$set);
                     var updateTimestamp = updateObject.$set.lastTimestamp;
-                    assert(beforeTimestamp.getTime() <= updateTimestamp.getTime(),
-                        "Timestamp is earlier than call"
-                    );
-                    assert(updateTimestamp.getTime() <= afterTimestamp.getTime(),
-                        "Timestamp is later than call"
-                    );
-                    assert.equal(response.statusCode, 200);
+                    assert.isAtLeast(updateTimestamp.getTime(), beforeTimestamp.getTime());
+                    assert.isAtMost(updateTimestamp.getTime(), afterTimestamp.getTime());
                 });
             }
         );

--- a/test/serverHelpers.js
+++ b/test/serverHelpers.js
@@ -218,12 +218,16 @@ module.exports.postMessage = function(conversationID, contents) {
         resolveWithFullResponse: true
     });
 };
-module.exports.getMessages = function(conversationID) {
+module.exports.getMessages = function(conversationID, timestamp) {
     var requestUrl = baseUrl + "/api/messages/" + conversationID;
-    return request({
+    var requestObject = {
         url: requestUrl,
         jar: cookieJar,
         simple: false,
         resolveWithFullResponse: true
-    });
+    };
+    if (timestamp) {
+        requestObject.qs = {timestamp: timestamp};
+    }
+    return request(requestObject);
 };

--- a/test/serverHelpers.js
+++ b/test/serverHelpers.js
@@ -39,7 +39,8 @@ function setupDB() {
         },
         messages: {
             find: sinon.stub(),
-            insertOne: sinon.stub()
+            insertOne: sinon.stub(),
+            count: sinon.stub()
         }
     };
     dbCursors = {};
@@ -118,6 +119,11 @@ module.exports.setInsertOneResult = function(collection, success, result, callNu
     var dbCursorCall = callNum === undefined ? dbCursor : dbCursor.onCall(callNum);
     dbCursorCall.returns(success ? Promise.resolve({ops: [result]}) : Promise.reject(result));
 };
+module.exports.setCountResult = function(collection, success, result, callNum) {
+    var dbCursor = dbCollections[collection].count;
+    var dbCursorCall = callNum === undefined ? dbCursor : dbCursor.onCall(callNum);
+    dbCursorCall.returns(success ? Promise.resolve(result) : Promise.reject(result));
+};
 
 module.exports.getFindCallCount = function(collection) {
     return dbCursors[collection].toArray.callCount;
@@ -131,6 +137,9 @@ module.exports.getInsertOneCallCount = function(collection) {
 module.exports.getUpdateOneCallCount = function(collection) {
     return dbCollections[collection].updateOne.callCount;
 };
+module.exports.getCountCallCount = function(collection) {
+    return dbCollections[collection].count.callCount;
+};
 
 module.exports.getFindAnyArgs = function(collection, callNum) {
     return dbCollections[collection].find.getCall(callNum).args;
@@ -140,6 +149,9 @@ module.exports.getInsertOneArgs = function(collection, callNum) {
 };
 module.exports.getUpdateOneArgs = function(collection, callNum) {
     return dbCollections[collection].updateOne.getCall(callNum).args;
+};
+module.exports.getCountArgs = function(collection, callNum) {
+    return dbCollections[collection].count.getCall(callNum).args;
 };
 
 module.exports.getOAuth = function(followRedirect) {
@@ -218,7 +230,7 @@ module.exports.postMessage = function(conversationID, contents) {
         resolveWithFullResponse: true
     });
 };
-module.exports.getMessages = function(conversationID, timestamp) {
+module.exports.getMessages = function(conversationID, queryParams) {
     var requestUrl = baseUrl + "/api/messages/" + conversationID;
     var requestObject = {
         url: requestUrl,
@@ -226,8 +238,8 @@ module.exports.getMessages = function(conversationID, timestamp) {
         simple: false,
         resolveWithFullResponse: true
     };
-    if (timestamp) {
-        requestObject.qs = {timestamp: timestamp};
+    if (queryParams) {
+        requestObject.qs = queryParams;
     }
     return request(requestObject);
 };

--- a/test/serverHelpers.js
+++ b/test/serverHelpers.js
@@ -34,7 +34,8 @@ function setupDB() {
         },
         conversations: {
             find: sinon.stub(),
-            insertOne: sinon.stub()
+            insertOne: sinon.stub(),
+            updateOne: sinon.stub()
         },
         messages: {
             find: sinon.stub(),
@@ -127,12 +128,18 @@ module.exports.getFindOneCallCount = function(collection) {
 module.exports.getInsertOneCallCount = function(collection) {
     return dbCollections[collection].insertOne.callCount;
 };
+module.exports.getUpdateOneCallCount = function(collection) {
+    return dbCollections[collection].updateOne.callCount;
+};
 
 module.exports.getFindAnyArgs = function(collection, callNum) {
     return dbCollections[collection].find.getCall(callNum).args;
 };
 module.exports.getInsertOneArgs = function(collection, callNum) {
     return dbCollections[collection].insertOne.getCall(callNum).args;
+};
+module.exports.getUpdateOneArgs = function(collection, callNum) {
+    return dbCollections[collection].updateOne.getCall(callNum).args;
 };
 
 module.exports.getOAuth = function(followRedirect) {


### PR DESCRIPTION
@stevenhillcox @sievins @jebbinSCL

Adds features to the server for tracking conversations and messages in time, including adding a timestamp for the last received message to conversations, getting only messages newer than a certain point from the server, and getting the number of messages matched by a query instead of the full set of results (useful for client-side notifications of new messages).
