### PR TITLE
Set circle.yml to use staging branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,6 @@ deployment:
     heroku:
       appname: chat-grad-project-steve
   staging:
-    branch: /.*/
+    branch: staging
     heroku:
       appname: chat-grad-project-steve-stage


### PR DESCRIPTION
@stevenhillcox @sievins @jebbinSCL

This doesn't make much of a difference as long as merges are made to the `staging` branch before the `master` branch from here on, but it reduces the number of "Build failed" emails I get from running staging tests on every branch constantly.
