### PR TITLE
Reorganize server api

### DIFF
--- a/server/conversations.js
+++ b/server/conversations.js
@@ -1,0 +1,65 @@
+/*global Promise */
+
+module.exports = function(app, db, baseUrl) {
+    var dbActions = require("./dbActions")(db);
+
+    var users = db.collection("users");
+    var conversations = db.collection("conversations");
+
+    app.get(baseUrl + "/conversations/:id", function(req, res) {
+        var conversationID = getConversationID(req.session.user, req.params.id);
+        conversations.find({
+            _id: conversationID
+        }).limit(1).next().then(function(conversation) {
+            if (conversation) {
+                res.json(dbActions.cleanIdField(conversation));
+            } else {
+                res.sendStatus(404);
+            }
+        }).catch(function(err) {
+            res.sendStatus(500);
+        });
+    });
+
+    app.post(baseUrl + "/conversations", function(req, res) {
+        var conversationInfo = req.body;
+        var recipientID = conversationInfo.recipient;
+        var senderID = req.session.user;
+        // Find both the sender and the recipient in the db
+        findUsers([senderID, recipientID]).then(function() {
+            var conversationID = getConversationID(senderID, recipientID);
+            var participants = [senderID, recipientID].sort();
+            return conversations.insertOne({
+                _id: conversationID,
+                participants: participants
+            });
+        }).then(function(result) {
+            res.json(dbActions.cleanIdField(result.ops[0]));
+        }).catch(function(err) {
+            res.sendStatus(500);
+        });
+    });
+
+    function findUsers(userIDs) {
+        var findPromises = [];
+        userIDs.forEach(function(userID, idx) {
+            findPromises.push(users.find({
+                _id: userID
+            }).limit(1).next().then(function(foundUser) {
+                if (!foundUser) {
+                    return Promise.reject(false);
+                }
+                return foundUser;
+            }));
+        });
+        return Promise.all(findPromises);
+    }
+
+    // Produce the same ID for any pair of users, regardless of which is the sender
+    function getConversationID(userAId, userBId) {
+        return userAId < userBId ?
+            userAId + "," + userBId :
+            userBId + "," + userAId;
+    }
+
+};

--- a/server/dbActions.js
+++ b/server/dbActions.js
@@ -1,0 +1,38 @@
+/*global Promise */
+
+module.exports = function(db) {
+    var users = db.collection("users");
+    var conversations = db.collection("conversations");
+    var messages = db.collection("messages");
+    var notifications = db.collection("notifications");
+    var groups = db.collection("groups");
+
+    return {
+        cleanIdField: cleanIdField,
+        clearNotifications: clearNotifications
+    };
+
+    function clearNotifications(userID, type, data) {
+        var notificationQuery = {
+            userID: userID,
+            type: type
+        };
+        for (var key in data) {
+            notificationQuery["data." + key] = data[key];
+        }
+        notifications.deleteMany(notificationQuery);
+    }
+
+    // Returns a copy of the input with the "_id" field renamed to "id"
+    function cleanIdField(obj) {
+        var cleanObj = {};
+        for (var key in obj) {
+            if (key === "_id") {
+                cleanObj.id = obj._id;
+            } else {
+                cleanObj[key] = obj[key];
+            }
+        }
+        return cleanObj;
+    }
+};

--- a/server/groups.js
+++ b/server/groups.js
@@ -1,0 +1,108 @@
+/*global Promise */
+
+var ObjectID = require("mongodb").ObjectID;
+
+module.exports = function(app, db, baseUrl) {
+    var dbActions = require("./dbActions")(db);
+
+    var groups = db.collection("groups");
+
+    app.get(baseUrl + "/groups", function(req, res) {
+        var senderID = req.session.user;
+        var joinedOnly = req.query.joinedOnly;
+        var searchString = req.query.searchString;
+        var queryObject = {};
+        if (joinedOnly) {
+            queryObject.users = senderID;
+        }
+        if (searchString) {
+            queryObject.$text = {
+                $search: searchString
+            };
+        }
+        groups.find(queryObject).toArray().then(function(docs) {
+            var groupIDs = docs.map(function(group) {
+                return group._id;
+            });
+            dbActions.clearNotifications(senderID, "group_changed", {groupID: {$in: groupIDs}});
+            res.json(docs.map(dbActions.cleanIdField));
+        }).catch(function(err) {
+            res.sendStatus(500);
+        });
+    });
+
+    app.post(baseUrl + "/groups", function(req, res) {
+        var groupInfo = req.body;
+        var creatorID = req.session.user;
+        groups.find({
+            name: groupInfo.name
+        }).limit(1).next().then(function(group) {
+            if (group) {
+                res.sendStatus(409);
+                return Promise.resolve();
+            }
+            return groups.insertOne({
+                name: groupInfo.name,
+                description: groupInfo.description,
+                users: [creatorID]
+            }).then(function(result) {
+                res.json(dbActions.cleanIdField(result.ops[0]));
+            });
+        }).catch(function(err) {
+            res.sendStatus(500);
+        });
+    });
+
+    app.put(baseUrl + "/groups/:id", function(req, res) {
+        var groupID = req.params.id;
+        var groupInfo = req.body.groupInfo;
+        var newUsers = req.body.newUsers;
+        var removedUsers = req.body.removedUsers;
+        var queryObject = {_id: new ObjectID(groupID)};
+        groups.find(queryObject).limit(1).next().then(function(group) {
+            if (!group) {
+                res.sendStatus(404);
+                return Promise.resolve();
+            }
+            if (group.users.indexOf(req.session.user) === -1) {
+                res.sendStatus(403);
+                return Promise.resolve();
+            }
+            // For now, only allow users to remove themselves from a group
+            if (removedUsers && (removedUsers.length !== 1 || removedUsers[0] !== req.session.user)) {
+                res.sendStatus(409);
+                return Promise.resolve();
+            }
+            var updateObject = groupUpdateQuery(group, req.session.user, newUsers, removedUsers, groupInfo);
+            return groups.findOneAndUpdate(queryObject, updateObject, {
+                returnOriginal: false
+            }).then(function(updateResult) {
+                res.json(dbActions.cleanIdField(updateResult.value));
+            });
+        }).catch(function(err) {
+            res.sendStatus(500);
+        });
+    });
+
+    function groupUpdateQuery(group, senderID, newUsers, removedUsers, groupInfo) {
+        var updateObject = {};
+        if (newUsers) {
+            updateObject.$addToSet = {users: {$each: newUsers}};
+        }
+        if (removedUsers) {
+            updateObject.$pull = {users: {$in: removedUsers}};
+        }
+        if (groupInfo) {
+            updateObject.$set = {};
+            for (var item in groupInfo) {
+                // Don't update any fields that don't exist, the _id field (locked), or the users field
+                // (limited access)
+                if (group[item] && item !== "_id" && item !== "users") {
+                    updateObject.$set[item] = groupInfo[item];
+                }
+            }
+        }
+        return updateObject;
+    }
+
+};

--- a/server/messages.js
+++ b/server/messages.js
@@ -1,0 +1,116 @@
+/*global Promise */
+
+module.exports = function(app, db, baseUrl) {
+    var dbActions = require("./dbActions")(db);
+
+    var conversations = db.collection("conversations");
+    var messages = db.collection("messages");
+    var notifications = db.collection("notifications");
+
+    app.get(baseUrl + "/messages/:id", function(req, res) {
+        var senderID = req.session.user;
+        var conversationID = req.params.id;
+        var lastTimestamp = req.query.timestamp;
+        var countOnly = req.query.countOnly;
+        conversations.find({
+            _id: conversationID
+        }).limit(1).next().then(function(conversation) {
+            if (!conversation) {
+                return Promise.reject(false);
+            }
+            if (conversation.participants.indexOf(senderID) === -1) {
+                res.sendStatus(403);
+                return Promise.resolve();
+            }
+            var queryObject = {conversationID: conversationID};
+            if (lastTimestamp) {
+                queryObject.timestamp = {$gt: new Date(lastTimestamp)};
+            }
+            if (countOnly) {
+                return messages.count(queryObject).then(function(count) {
+                    res.json({count: count});
+                });
+            } else {
+                return messages.find(queryObject).toArray().then(function(docs) {
+                    dbActions.clearNotifications(senderID, "new_messages", {conversationID: conversationID});
+                    res.json(docs.map(dbActions.cleanIdField));
+                });
+            }
+        }).catch(function(err) {
+            res.sendStatus(500);
+        });
+    });
+
+    app.post(baseUrl + "/messages", function(req, res) {
+        var senderID = req.session.user;
+        var conversationID = req.body.conversationID;
+        var contents = req.body.contents;
+        if (contents === "") {
+            res.sendStatus(201);
+            return;
+        }
+        conversations.find({
+            _id: conversationID
+        }).limit(1).next().then(function(conversation) {
+            if (!conversation) {
+                return Promise.reject(false);
+            }
+            if (conversation.participants.indexOf(senderID) === -1) {
+                res.sendStatus(403);
+            }
+            var timestamp = new Date();
+            messages.insertOne({
+                senderID: senderID,
+                conversationID: conversationID,
+                contents: contents,
+                timestamp: timestamp
+            }).then(function(result) {
+                var message = result.ops[0];
+                updateConversation(conversation, message);
+                addNewMessageNotification(conversation, message);
+                res.json(dbActions.cleanIdField(message));
+            }).catch(function(err) {
+                res.sendStatus(500);
+            });
+        }).catch(function(err) {
+            res.sendStatus(500);
+        });
+    });
+
+    // Insert a "new_messages" notification for each participant, or if such a notification already exists then
+    // increment the messageCount
+    function addNewMessageNotification(conversation, message) {
+        conversation.participants.forEach(function(participant) {
+            notifications.updateOne({
+                userID: participant,
+                type: "new_messages",
+                "data.conversationID": conversation._id
+            }, {
+                $set: {
+                    userID: participant,
+                    type: "new_messages",
+                    "data.conversationID": conversation._id,
+                    "data.since": message.timestamp,
+                    "data.otherID": conversation.participants.filter(function(otherParticipant) {
+                        return otherParticipant !== participant;
+                    })[0]
+                },
+                $inc: {
+                    "data.messageCount": 1
+                }
+            }, {
+                upsert: true
+            });
+        });
+    }
+
+    // Update the conversation timestamp
+    function updateConversation(conversation, message) {
+        conversations.updateOne({
+            _id: conversation._id
+        }, {
+            $set: {lastTimestamp: message.timestamp}
+        });
+    }
+
+};

--- a/server/notifications.js
+++ b/server/notifications.js
@@ -1,0 +1,19 @@
+/*global Promise */
+
+module.exports = function(app, db, baseUrl) {
+    var dbActions = require("./dbActions")(db);
+
+    var notifications = db.collection("notifications");
+
+    app.get(baseUrl + "/notifications", function(req, res) {
+        var userID = req.session.user;
+        notifications.find({
+            userID: userID
+        }).toArray().then(function(docs) {
+            res.json(docs.map(dbActions.cleanIdField));
+        }).catch(function(err) {
+            res.sendStatus(500);
+        });
+    });
+
+};

--- a/server/server.js
+++ b/server/server.js
@@ -5,12 +5,19 @@ var cookieParser = require("cookie-parser");
 var bodyParser = require("body-parser");
 var mongo = require("mongodb");
 
+var addConversationsAPI = require("./conversations");
+var addMessagesAPI = require("./messages");
+var addGroupsAPI = require("./groups");
+var addNotificationsAPI = require("./notifications");
+
 module.exports = function(port, db, githubAuthoriser) {
     var app = express();
 
     app.use(express.static("public"));
     app.use(cookieParser());
     app.use(bodyParser.json());
+
+    var dbActions = require("./dbActions")(db);
 
     var users = db.collection("users");
     var conversations = db.collection("conversations");
@@ -83,306 +90,16 @@ module.exports = function(port, db, githubAuthoriser) {
 
     app.get("/api/users", function(req, res) {
         users.find().toArray().then(function(docs) {
-            res.json(docs.map(cleanIdField));
+            res.json(docs.map(dbActions.cleanIdField));
         }).catch(function(err) {
             res.sendStatus(500);
         });
     });
 
-    // Produce the same ID for any pair of users, regardless of which is the sender
-    function getConversationID(userAId, userBId) {
-        return userAId < userBId ?
-            userAId + "," + userBId :
-            userBId + "," + userAId;
-    }
-
-    app.get("/api/conversations/:id", function(req, res) {
-        var conversationID = getConversationID(req.session.user, req.params.id);
-        conversations.find({
-            _id: conversationID
-        }).limit(1).next().then(function(conversation) {
-            if (conversation) {
-                res.json(cleanIdField(conversation));
-            } else {
-                res.sendStatus(404);
-            }
-        }).catch(function(err) {
-            res.sendStatus(500);
-        });
-    });
-
-    function findUsers(userIDs) {
-        var findPromises = [];
-        userIDs.forEach(function(userID, idx) {
-            findPromises.push(users.find({
-                _id: userID
-            }).limit(1).next().then(function(foundUser) {
-                if (!foundUser) {
-                    return Promise.reject(false);
-                }
-                return foundUser;
-            }));
-        });
-        return Promise.all(findPromises);
-    }
-
-    app.post("/api/conversations", function(req, res) {
-        var conversationInfo = req.body;
-        var recipientID = conversationInfo.recipient;
-        var senderID = req.session.user;
-        // Find both the sender and the recipient in the db
-        findUsers([senderID, recipientID]).then(function() {
-            var conversationID = getConversationID(senderID, recipientID);
-            var participants = [senderID, recipientID].sort();
-            return conversations.insertOne({
-                _id: conversationID,
-                participants: participants
-            });
-        }).then(function(result) {
-            res.json(cleanIdField(result.ops[0]));
-        }).catch(function(err) {
-            res.sendStatus(500);
-        });
-    });
-
-    // Update the conversation timestamp
-    function updateConversation(conversation, message) {
-        conversations.updateOne({
-            _id: conversation._id
-        }, {
-            $set: {lastTimestamp: message.timestamp}
-        });
-    }
-
-    // Insert a "new_messages" notification for each participant, or if such a notification already exists then
-    // increment the messageCount
-    function addNewMessageNotification(conversation, message) {
-        conversation.participants.forEach(function(participant) {
-            notifications.updateOne({
-                userID: participant,
-                type: "new_messages",
-                "data.conversationID": conversation._id
-            }, {
-                $set: {
-                    userID: participant,
-                    type: "new_messages",
-                    "data.conversationID": conversation._id,
-                    "data.since": message.timestamp,
-                    "data.otherID": conversation.participants.filter(function(otherParticipant) {
-                        return otherParticipant !== participant;
-                    })[0]
-                },
-                $inc: {
-                    "data.messageCount": 1
-                }
-            }, {
-                upsert: true
-            });
-        });
-    }
-
-    app.post("/api/messages", function(req, res) {
-        var senderID = req.session.user;
-        var conversationID = req.body.conversationID;
-        var contents = req.body.contents;
-        if (contents === "") {
-            res.sendStatus(201);
-            return;
-        }
-        conversations.find({
-            _id: conversationID
-        }).limit(1).next().then(function(conversation) {
-            if (!conversation) {
-                return Promise.reject(false);
-            }
-            if (conversation.participants.indexOf(senderID) === -1) {
-                res.sendStatus(403);
-            }
-            var timestamp = new Date();
-            messages.insertOne({
-                senderID: senderID,
-                conversationID: conversationID,
-                contents: contents,
-                timestamp: timestamp
-            }).then(function(result) {
-                var message = result.ops[0];
-                updateConversation(conversation, message);
-                addNewMessageNotification(conversation, message);
-                res.json(cleanIdField(message));
-            }).catch(function(err) {
-                res.sendStatus(500);
-            });
-        }).catch(function(err) {
-            res.sendStatus(500);
-        });
-    });
-
-    app.get("/api/messages/:id", function(req, res) {
-        var senderID = req.session.user;
-        var conversationID = req.params.id;
-        var lastTimestamp = req.query.timestamp;
-        var countOnly = req.query.countOnly;
-        conversations.find({
-            _id: conversationID
-        }).limit(1).next().then(function(conversation) {
-            if (!conversation) {
-                return Promise.reject(false);
-            }
-            if (conversation.participants.indexOf(senderID) === -1) {
-                res.sendStatus(403);
-                return Promise.resolve();
-            }
-            var queryObject = {conversationID: conversationID};
-            if (lastTimestamp) {
-                queryObject.timestamp = {$gt: new Date(lastTimestamp)};
-            }
-            if (countOnly) {
-                return messages.count(queryObject).then(function(count) {
-                    res.json({count: count});
-                });
-            } else {
-                return messages.find(queryObject).toArray().then(function(docs) {
-                    clearNotifications(senderID, "new_messages", {conversationID: conversationID});
-                    res.json(docs.map(cleanIdField));
-                });
-            }
-        }).catch(function(err) {
-            res.sendStatus(500);
-        });
-    });
-
-    app.get("/api/notifications", function(req, res) {
-        var userID = req.session.user;
-        notifications.find({
-            userID: userID
-        }).toArray().then(function(docs) {
-            res.json(docs.map(cleanIdField));
-        }).catch(function(err) {
-            res.sendStatus(500);
-        });
-    });
-
-    app.get("/api/groups", function(req, res) {
-        var senderID = req.session.user;
-        var joinedOnly = req.query.joinedOnly;
-        var searchString = req.query.searchString;
-        var queryObject = {};
-        if (joinedOnly) {
-            queryObject.users = senderID;
-        }
-        if (searchString) {
-            queryObject.$text = {
-                $search: searchString
-            };
-        }
-        groups.find(queryObject).toArray().then(function(docs) {
-            var groupIDs = docs.map(function(group) {
-                return group._id;
-            });
-            clearNotifications(senderID, "group_changed", {groupID: {$in: groupIDs}});
-            res.json(docs.map(cleanIdField));
-        }).catch(function(err) {
-            res.sendStatus(500);
-        });
-    });
-
-    app.post("/api/groups", function(req, res) {
-        var groupInfo = req.body;
-        var creatorID = req.session.user;
-        groups.find({
-            name: groupInfo.name
-        }).limit(1).next().then(function(group) {
-            if (group) {
-                res.sendStatus(409);
-                return Promise.resolve();
-            }
-            return groups.insertOne({
-                name: groupInfo.name,
-                description: groupInfo.description,
-                users: [creatorID]
-            }).then(function(result) {
-                res.json(cleanIdField(result.ops[0]));
-            });
-        }).catch(function(err) {
-            res.sendStatus(500);
-        });
-    });
-
-    function groupUpdateQuery(group, senderID, newUsers, removedUsers, groupInfo) {
-        var updateObject = {};
-        if (newUsers) {
-            updateObject.$addToSet = {users: {$each: newUsers}};
-        }
-        if (removedUsers) {
-            updateObject.$pull = {users: {$in: removedUsers}};
-        }
-        if (groupInfo) {
-            updateObject.$set = {};
-            for (var item in groupInfo) {
-                // Don't update any fields that don't exist, the _id field (locked), or the users field
-                // (limited access)
-                if (group[item] && item !== "_id" && item !== "users") {
-                    updateObject.$set[item] = groupInfo[item];
-                }
-            }
-        }
-        return updateObject;
-    }
-
-    app.put("/api/groups/:id", function(req, res) {
-        var groupID = req.params.id;
-        var groupInfo = req.body.groupInfo;
-        var newUsers = req.body.newUsers;
-        var removedUsers = req.body.removedUsers;
-        var queryObject = {_id: new mongo.ObjectID(groupID)};
-        groups.find(queryObject).limit(1).next().then(function(group) {
-            if (!group) {
-                res.sendStatus(404);
-                return Promise.resolve();
-            }
-            if (group.users.indexOf(req.session.user) === -1) {
-                res.sendStatus(403);
-                return Promise.resolve();
-            }
-            // For now, only allow users to remove themselves from a group
-            if (removedUsers && (removedUsers.length !== 1 || removedUsers[0] !== req.session.user)) {
-                res.sendStatus(409);
-                return Promise.resolve();
-            }
-            var updateObject = groupUpdateQuery(group, req.session.user, newUsers, removedUsers, groupInfo);
-            return groups.findOneAndUpdate(queryObject, updateObject, {
-                returnOriginal: false
-            }).then(function(updateResult) {
-                res.json(cleanIdField(updateResult.value));
-            });
-        }).catch(function(err) {
-            res.sendStatus(500);
-        });
-    });
-
-    // Returns a copy of the input with the "_id" field renamed to "id"
-    function cleanIdField(obj) {
-        var cleanObj = {};
-        for (var key in obj) {
-            if (key === "_id") {
-                cleanObj.id = obj._id;
-            } else {
-                cleanObj[key] = obj[key];
-            }
-        }
-        return cleanObj;
-    }
-
-    function clearNotifications(userID, type, data) {
-        var notificationQuery = {
-            userID: userID,
-            type: type
-        };
-        for (var key in data) {
-            notificationQuery["data." + key] = data[key];
-        }
-        notifications.deleteMany(notificationQuery);
-    }
+    addConversationsAPI(app, db, "/api");
+    addMessagesAPI(app, db, "/api");
+    addNotificationsAPI(app, db, "/api");
+    addGroupsAPI(app, db, "/api");
 
     return app.listen(port);
 };


### PR DESCRIPTION
@stevenhillcox @sievins @jebbinSCL

Splits most of the endpoints that make up the API into separate files, grouped by feature (groups, conversations, etc). Does not contain any logical changes, and is intended to be followed by further modularisation (moving direct db access entirely into dbActions and splitting certain endpoints up by use), and a corresponding splitting of the test logic.
