### PR TITLE
Split api routing

### DIFF
--- a/public/js/controllers/groupsSection.controller.js
+++ b/public/js/controllers/groupsSection.controller.js
@@ -65,7 +65,7 @@
         }
 
         function joinGroup(groupID) {
-            return chatDataService.addGroupMember(groupID, $scope.user()._id);
+            return chatDataService.joinGroup(groupID);
         }
 
         function startEditGroup() {
@@ -108,7 +108,7 @@
                 return user.name === recipientUsername;
             });
             if (recipient) {
-                return chatDataService.addGroupMember(vm.currentGroup.id, recipient.id);
+                return chatDataService.inviteUserToGroup(vm.currentGroup.id, recipient.id);
             } else {
                 return Promise.reject();
             }

--- a/public/js/services/chatData.service.js
+++ b/public/js/services/chatData.service.js
@@ -15,12 +15,15 @@
             getConversation: getConversation,
             createConversation: createConversation,
             getConversationMessages: getConversationMessages,
+            getConversationMessageCount: getConversationMessageCount,
             submitMessage: submitMessage,
             getNotifications: getNotifications,
             getGroups: getGroups,
             createGroup: createGroup,
             updateGroupInfo: updateGroupInfo,
-            addGroupMember: addGroupMember
+            inviteUserToGroup: inviteUserToGroup,
+            removeUserFromGroup: removeUserFromGroup,
+            joinGroup: joinGroup
         };
 
         function getSelf() {
@@ -55,6 +58,14 @@
                 return $http.get("/api/messages/" + conversationID, {params: params});
             } else {
                 return $http.get("/api/messages/" + conversationID);
+            }
+        }
+
+        function getConversationMessageCount(conversationID, params) {
+            if (params) {
+                return $http.get("/api/messages/" + conversationID + "/count", {params: params});
+            } else {
+                return $http.get("/api/messages/" + conversationID + "/count");
             }
         }
 
@@ -104,29 +115,46 @@
         function updateGroupInfo(groupID, name, description) {
             return $http({
                 method: "PUT",
-                url: "/api/groups/" + groupID,
+                url: "/api/groups/" + groupID + "/update",
                 headers: {
                     "Content-type": "application/json"
                 },
                 data: JSON.stringify({
-                    groupInfo: {
-                        name: name,
-                        description: description
-                    }
+                    name: name,
+                    description: description
                 })
             });
         }
 
-        function addGroupMember(groupID, userID) {
+        function inviteUserToGroup(groupID, userID) {
             return $http({
                 method: "PUT",
-                url: "/api/groups/" + groupID,
+                url: "/api/groups/" + groupID + "/invite",
                 headers: {
                     "Content-type": "application/json"
                 },
-                data: JSON.stringify({
-                    newUsers: [userID]
-                })
+                data: JSON.stringify([userID])
+            });
+        }
+
+        function removeUserFromGroup(groupID, userID) {
+            return $http({
+                method: "PUT",
+                url: "/api/groups/" + groupID + "/remove",
+                headers: {
+                    "Content-type": "application/json"
+                },
+                data: JSON.stringify([userID])
+            });
+        }
+
+        function joinGroup(groupID) {
+            return $http({
+                method: "PUT",
+                url: "/api/groups/" + groupID + "/join",
+                headers: {
+                    "Content-type": "application/json"
+                }
             });
         }
     }

--- a/server/groups.js
+++ b/server/groups.js
@@ -67,9 +67,9 @@ module.exports = function(app, db, baseUrl) {
                     updateObject.$set[item] = groupInfo[item];
                 }
             }
-            return updateGroup(queryObject, updateObject).then(function(updatedGroup) {
-                res.json(updatedGroup);
-            });
+            return updateGroup(queryObject, updateObject);
+        }).then(function(updatedGroup) {
+            res.json(updatedGroup);
         }).catch(function(errorCode) {
             res.sendStatus(errorCode);
         });
@@ -81,9 +81,9 @@ module.exports = function(app, db, baseUrl) {
         var newUsers = req.body;
         var queryObject = {_id: new ObjectID(groupID)};
         findAndValidateGroup(userID, queryObject).then(function(group) {
-            return updateGroup(queryObject, {$addToSet: {users: {$each: newUsers}}}).then(function(updatedGroup) {
-                res.json(updatedGroup);
-            });
+            return updateGroup(queryObject, {$addToSet: {users: {$each: newUsers}}});
+        }).then(function(updatedGroup) {
+            res.json(updatedGroup);
         }).catch(function(errorCode) {
             res.sendStatus(errorCode);
         });
@@ -99,9 +99,9 @@ module.exports = function(app, db, baseUrl) {
             if (removedUsers && (removedUsers.length !== 1 || removedUsers[0] !== userID)) {
                 return Promise.reject(409);
             }
-            return updateGroup(queryObject, {$pull: {users: {$in: removedUsers}}}).then(function(updatedGroup) {
-                res.json(updatedGroup);
-            });
+            return updateGroup(queryObject, {$pull: {users: {$in: removedUsers}}});
+        }).then(function(updatedGroup) {
+            res.json(updatedGroup);
         }).catch(function(errorCode) {
             res.sendStatus(errorCode);
         });
@@ -112,9 +112,9 @@ module.exports = function(app, db, baseUrl) {
         var groupID = req.params.id;
         var queryObject = {_id: new ObjectID(groupID)};
         findAndValidateGroup(userID, queryObject, {}, false).then(function(group) {
-            return updateGroup(queryObject, {$addToSet: {users: userID}}).then(function(updatedGroup) {
-                res.json(updatedGroup);
-            });
+            return updateGroup(queryObject, {$addToSet: {users: userID}});
+        }).then(function(updatedGroup) {
+            res.json(updatedGroup);
         }).catch(function(errorCode) {
             res.sendStatus(errorCode);
         });

--- a/server/messages.js
+++ b/server/messages.js
@@ -56,14 +56,14 @@ module.exports = function(app, db, baseUrl) {
                 conversationID: conversationID,
                 contents: contents,
                 timestamp: timestamp
+            }).then(function(result) {
+                var message = result.ops[0];
+                updateConversation(conversation, message);
+                addNewMessageNotification(conversation, message);
+                res.json(dbActions.cleanIdField(message));
             }).catch(function(err) {
                 return Promise.reject(500);
             });
-        }).then(function(result) {
-            var message = result.ops[0];
-            updateConversation(conversation, message);
-            addNewMessageNotification(conversation, message);
-            res.json(dbActions.cleanIdField(message));
         }).catch(function(errorCode) {
             res.sendStatus(errorCode);
         });

--- a/server/messages.js
+++ b/server/messages.js
@@ -14,12 +14,12 @@ module.exports = function(app, db, baseUrl) {
         var countOnly = req.query.countOnly;
         findAndValidateConversation(senderID, {_id: conversationID}).then(function(conversation) {
             var queryObject = messageQuery(conversationID, lastTimestamp);
-            return messages.find(queryObject).toArray().then(function(docs) {
-                dbActions.clearNotifications(senderID, "new_messages", {conversationID: conversationID});
-                res.json(docs.map(dbActions.cleanIdField));
-            }).catch(function(err) {
+            return messages.find(queryObject).toArray().catch(function(err) {
                 return Promise.reject(500);
             });
+        }).then(function(docs) {
+            dbActions.clearNotifications(senderID, "new_messages", {conversationID: conversationID});
+            res.json(docs.map(dbActions.cleanIdField));
         }).catch(function(errorCode) {
             res.sendStatus(errorCode);
         });
@@ -31,11 +31,11 @@ module.exports = function(app, db, baseUrl) {
         var lastTimestamp = req.query.timestamp;
         findAndValidateConversation(senderID, {_id: conversationID}).then(function(conversation) {
             var queryObject = messageQuery(conversationID, lastTimestamp);
-            return messages.count(queryObject).then(function(count) {
-                res.json({count: count});
-            }).catch(function(err) {
+            return messages.count(queryObject).catch(function(err) {
                 return Promise.reject(500);
             });
+        }).then(function(count) {
+            res.json({count: count});
         }).catch(function(errorCode) {
             res.sendStatus(errorCode);
         });
@@ -56,14 +56,14 @@ module.exports = function(app, db, baseUrl) {
                 conversationID: conversationID,
                 contents: contents,
                 timestamp: timestamp
-            }).then(function(result) {
-                var message = result.ops[0];
-                updateConversation(conversation, message);
-                addNewMessageNotification(conversation, message);
-                res.json(dbActions.cleanIdField(message));
             }).catch(function(err) {
                 return Promise.reject(500);
             });
+        }).then(function(result) {
+            var message = result.ops[0];
+            updateConversation(conversation, message);
+            addNewMessageNotification(conversation, message);
+            res.json(dbActions.cleanIdField(message));
         }).catch(function(errorCode) {
             res.sendStatus(errorCode);
         });

--- a/test/serverHelpers.js
+++ b/test/serverHelpers.js
@@ -325,18 +325,52 @@ module.exports.postGroup = function(name, description) {
         resolveWithFullResponse: true
     });
 };
-module.exports.putGroup = function(id, groupInfo, newUsers, removedUsers) {
-    var requestUrl = baseUrl + "/api/groups/" + id;
+module.exports.updateGroup = function(id, groupInfo) {
+    var requestUrl = baseUrl + "/api/groups/" + id + "/update";
     return request.put({
         url: requestUrl,
         headers: {
             "Content-type": "application/json"
         },
-        body: JSON.stringify({
-            groupInfo: groupInfo,
-            newUsers: newUsers,
-            removedUsers: removedUsers
-        }),
+        body: JSON.stringify(groupInfo),
+        jar: cookieJar,
+        simple: false,
+        resolveWithFullResponse: true
+    });
+};
+module.exports.inviteToGroup = function(id, newUsers) {
+    var requestUrl = baseUrl + "/api/groups/" + id + "/invite";
+    return request.put({
+        url: requestUrl,
+        headers: {
+            "Content-type": "application/json"
+        },
+        body: JSON.stringify(newUsers),
+        jar: cookieJar,
+        simple: false,
+        resolveWithFullResponse: true
+    });
+};
+module.exports.removeFromGroup = function(id, removedUsers) {
+    var requestUrl = baseUrl + "/api/groups/" + id + "/remove";
+    return request.put({
+        url: requestUrl,
+        headers: {
+            "Content-type": "application/json"
+        },
+        body: JSON.stringify(removedUsers),
+        jar: cookieJar,
+        simple: false,
+        resolveWithFullResponse: true
+    });
+};
+module.exports.joinGroup = function(id) {
+    var requestUrl = baseUrl + "/api/groups/" + id + "/join";
+    return request.put({
+        url: requestUrl,
+        headers: {
+            "Content-type": "application/json"
+        },
         jar: cookieJar,
         simple: false,
         resolveWithFullResponse: true

--- a/test/serverHelpers.js
+++ b/test/serverHelpers.js
@@ -283,6 +283,19 @@ module.exports.getMessages = function(conversationID, queryParams) {
     }
     return request(requestObject);
 };
+module.exports.getMessageCount = function(conversationID, queryParams) {
+    var requestUrl = baseUrl + "/api/messages/" + conversationID + "/count";
+    var requestObject = {
+        url: requestUrl,
+        jar: cookieJar,
+        simple: false,
+        resolveWithFullResponse: true
+    };
+    if (queryParams) {
+        requestObject.qs = queryParams;
+    }
+    return request(requestObject);
+};
 module.exports.getNotifications = function(conversationID, queryParams) {
     var requestUrl = baseUrl + "/api/notifications";
     var requestObject = {


### PR DESCRIPTION
@stevenhillcox @sievins @jebbinSCL

Splits up two API endpoints that had multiple functions into multiple endpoints, each with a single function. There are a few internal logical changes in the modules resulting from shared code in the newly split endpoints being extracted and simplified, but as far as the tests are concerned nothing logical has changed (besides the split itself).

The next intended step is to pull direct database access out of the server API modules, and then break up the tests on a per-module basis, as the test file has reached critical mass (actually pretty sure it hit it long ago).
